### PR TITLE
feat(stateless-mcp-on-lambda-python): initial implementation

### DIFF
--- a/stateless-mcp-on-lambda-python/.gitignore
+++ b/stateless-mcp-on-lambda-python/.gitignore
@@ -1,0 +1,6 @@
+# directories
+build
+
+# files
+*_output.yaml
+build.toml

--- a/stateless-mcp-on-lambda-python/README.md
+++ b/stateless-mcp-on-lambda-python/README.md
@@ -1,0 +1,75 @@
+# Stateless MCP on AWS Lambda (Python)
+
+This project demonstrates how to deploy a stateless MCP (Message Control Protocol) server on AWS Lambda using Python. The implementation uses AWS API Gateway for HTTP endpoints and AWS Lambda for serverless execution.
+
+## Prerequisites
+
+- AWS CLI configured with appropriate credentials
+- Python 3.x
+- Make
+- AWS SAM CLI
+- Docker Desktop or Podman for local builds
+- MCP Inspector tool for testing
+
+## Project Structure
+
+```
+stateless-mcp-on-lambda-python/
+├── build/         # Build artifacts
+├── etc/           # Configuration files
+├── sam/           # SAM template files
+├── src/           # Source code
+├── tmp/           # Temporary files
+└── makefile       # Build and deployment commands
+```
+
+## Configuration
+
+Before deploying, you need to configure the environment variables in `etc/environment.sh`:
+
+1. AWS Configuration:
+   - `PROFILE`: Your AWS CLI profile name
+   - `BUCKET`: S3 bucket name for deployment artifacts
+   - `REGION`: AWS region (default: us-east-1)
+
+2. MCP Dependencies:
+   - `P_DESCRIPTION`: MCP package version (default: "mcp==1.8.0")
+   - `O_LAYER_ARN`: This will be updated after creating the Lambda layer
+
+3. API Gateway and Lambda Configuration:
+   - `P_API_STAGE`: API Gateway stage name (default: dev)
+   - `P_FN_MEMORY`: Lambda function memory in MB (default: 128)
+   - `P_FN_TIMEOUT`: Lambda function timeout in seconds (default: 15)
+
+## Deployment Steps
+
+1. Create the Lambda Layer:
+   ```bash
+   make layer
+   ```
+   After execution, copy the `outLayer` value and update the `O_LAYER_ARN` in `etc/environment.sh`.
+
+2. Deploy the API Gateway and Lambda function:
+   ```bash
+   make apigw
+   ```
+   This will create the API Gateway and Lambda function, which will have the MCP dependencies layer attached.
+
+## Testing
+
+1. After deployment, you'll receive an `outApiEndpoint` value.
+2. Use the MCP Inspector tool to test the endpoint:
+   - Enter the following URL in MCP Inspector: `${outApiEndpoint}/echo/mcp/`
+
+## Make Commands
+
+- `make layer`: Creates the Lambda layer with MCP dependencies
+- `make apigw`: Deploys the API Gateway and Lambda function
+
+## Troubleshooting
+
+If you encounter any issues:
+1. Ensure all environment variables are properly set in `etc/environment.sh`
+2. Verify AWS credentials are correctly configured
+3. Check AWS CloudWatch logs for Lambda function errors
+4. Ensure the S3 bucket specified in `BUCKET` exists and is accessible

--- a/stateless-mcp-on-lambda-python/etc/environment.sh
+++ b/stateless-mcp-on-lambda-python/etc/environment.sh
@@ -1,0 +1,21 @@
+# aws configuration
+PROFILE=your-cli-profile
+BUCKET=your-cli-bucket
+REGION=us-east-1
+
+# mcp dependencies
+P_DESCRIPTION="mcp==1.8.0"
+LAYER_STACK=mcp-lambda-layer
+LAYER_TEMPLATE=iac/layer.yaml
+LAYER_OUTPUT=iac/layer_output.yaml
+LAYER_PARAMS="ParameterKey=description,ParameterValue=${P_DESCRIPTION}"
+O_LAYER_ARN=your-output-layer-arn
+
+# api gateway and lambdastack
+P_API_STAGE=dev
+P_FN_MEMORY=128
+P_FN_TIMEOUT=15
+APIGW_STACK=mcp-apigw
+APIGW_TEMPLATE=iac/template.yaml
+APIGW_OUTPUT=iac/template_output.yaml
+APIGW_PARAMS="ParameterKey=apiStage,ParameterValue=${P_API_STAGE} ParameterKey=fnMemory,ParameterValue=${P_FN_MEMORY} ParameterKey=fnTimeout,ParameterValue=${P_FN_TIMEOUT} ParameterKey=dependencies,ParameterValue=${O_LAYER_ARN}"

--- a/stateless-mcp-on-lambda-python/makefile
+++ b/stateless-mcp-on-lambda-python/makefile
@@ -1,0 +1,19 @@
+include etc/environment.sh
+
+# dependencies
+layer: layer.build layer.package layer.deploy
+layer.build:
+	sam build -t ${LAYER_TEMPLATE} --parameter-overrides ${LAYER_PARAMS} --build-dir build --manifest src/layer/requirements.txt --use-container
+layer.package:
+	sam package -t build/template.yaml --region ${REGION} --output-template-file ${LAYER_OUTPUT} --s3-bucket ${BUCKET} --s3-prefix ${LAYER_STACK}
+layer.deploy:
+	sam deploy -t ${LAYER_OUTPUT} --region ${REGION} --stack-name ${LAYER_STACK} --parameter-overrides ${LAYER_PARAMS} --capabilities CAPABILITY_NAMED_IAM
+
+# api gateway
+apigw: apigw.package apigw.deploy
+apigw.package:
+	sam package -t ${APIGW_TEMPLATE} --output-template-file ${APIGW_OUTPUT} --s3-bucket ${BUCKET} --s3-prefix ${APIGW_STACK}
+apigw.deploy:
+	sam deploy -t ${APIGW_OUTPUT} --region ${REGION} --stack-name ${APIGW_STACK} --parameter-overrides ${APIGW_PARAMS} --capabilities CAPABILITY_NAMED_IAM
+apigw.delete:
+	sam delete --stack-name ${APIGW_STACK}

--- a/stateless-mcp-on-lambda-python/sam/layer.yaml
+++ b/stateless-mcp-on-lambda-python/sam/layer.yaml
@@ -1,0 +1,23 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: MCP dependencies for Lambda
+Transform: AWS::Serverless-2016-10-31
+Parameters:
+  description:
+    Type: String
+Resources:
+  LayerMcp:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+      CompatibleRuntimes:
+        - python3.11
+        - python3.12
+      ContentUri: src/dependencies
+      Description: !Ref description
+      LayerName: mcp-dependencies-python3
+    Metadata:
+      BuildMethod: python3.12
+      BuildProperties:
+        UseContainer: true
+Outputs:
+  outLayer:
+    Value: !Ref LayerMcp

--- a/stateless-mcp-on-lambda-python/sam/openapi.yaml
+++ b/stateless-mcp-on-lambda-python/sam/openapi.yaml
@@ -1,0 +1,51 @@
+openapi: 3.0.1
+info:
+  title: apigw-mcp
+  description: API Gateway endpoint for MCP server
+  version: 0.1.0
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+
+components:
+  schemas:
+    error:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+  responses:
+    error:
+      description: internal server error
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/error"
+          example:
+            code: 500
+            message: "unable to retrieve message"
+
+paths:
+  /echo/mcp:
+    post:
+      summary: echo
+      description: endpoint for mcp server
+      responses:
+        200:
+          description: ok
+        500:
+          $ref: "#/components/responses/error"
+        default:
+          $ref: "#/components/responses/error"
+      x-amazon-apigateway-integration:
+        httpMethod: POST
+        payloadFormatVersion: "1.0"
+        responses:
+          default:
+            statusCode: 200
+        type: AWS_PROXY
+        uri:
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${Fn}/invocations"

--- a/stateless-mcp-on-lambda-python/sam/template.yaml
+++ b/stateless-mcp-on-lambda-python/sam/template.yaml
@@ -1,0 +1,120 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: MCP deployment on API Gateway and Lambda
+Transform: AWS::Serverless-2016-10-31
+Globals:
+  Api:
+    OpenApiVersion: 3.0.1
+  Function:
+    Layers:
+      - arn:aws:lambda:us-east-1:580247275435:layer:LambdaInsightsExtension:55
+      - arn:aws:lambda:us-east-1:753240598075:layer:LambdaAdapterLayerX86:25
+      - !Ref dependencies
+    MemorySize: !Ref fnMemory
+    Runtime: python3.12
+    Timeout: !Ref fnTimeout
+    Tracing: Active
+Parameters:
+  apiStage:
+    Type: String
+  fnMemory:
+    Type: Number
+  fnTimeout:
+    Type: Number
+  dependencies:
+    Type: String
+Resources:
+  # APIGW
+  Api:
+    Type: AWS::Serverless::Api
+    Properties:
+      AccessLogSetting:
+        DestinationArn: !GetAtt ApiLogGroup.Arn
+        Format: '{ "requestId":"$context.requestId", "ip": "$context.identity.sourceIp", "requestTime":"$context.requestTime", "httpMethod":"$context.httpMethod","routeKey":"$context.routeKey", "status":"$context.status","protocol":"$context.protocol", "responseLength":"$context.responseLength", "auth.status":"$context.authorizer.status", "auth.error":"$context.authorizer.error", "auth.token":"$context.authorizer.token", "auth.reason":"$context.authorizer.reason", "auth.simple":"$context.authorizer.simple", "auth.pversion":"$context.authorizer.pversion" }'
+      StageName: !Ref apiStage
+      DefinitionBody:
+        Fn::Transform:
+          Name: AWS::Include
+          Parameters:
+            Location: openapi.yaml
+  ApiLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/apigateway/apigw-mcp-${Api}"
+      RetentionInDays: 7
+  # Lambda
+  FnRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: cloudwatch-insights
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                Resource: '*'
+        - PolicyName: cloudwatch-logs
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                  - logs:DescribeLogStreams
+                Resource: 'arn:aws:logs:*:*:log-group:*:*'
+        - PolicyName: xray
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - xray:PutTraceSegments
+                  - xray:PutTelemetryRecords
+                  - xray:GetSamplingRules
+                  - xray:GetSamplingTargets
+                  - xray:GetSamplingStatisticSummaries
+                Resource: '*'
+  Fn:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../src/mcpserver
+      Handler: run.sh
+      Role: !GetAtt FnRole.Arn
+      Environment:
+        Variables:
+          AWS_LAMBDA_EXEC_WRAPPER: /opt/bootstrap
+          PORT: 8000
+      Tags:
+        application:group: example_group
+        application:owner: example_owner
+  FnLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub '/aws/lambda/${Fn}'
+      RetentionInDays: 7
+  FnPerm:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt Fn.Arn
+      Principal: apigateway.amazonaws.com
+      Action: lambda:InvokeFunction
+      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${Api}/*/*/*'
+Outputs:
+  outApi:
+    Value: !Ref Api
+  outApiEndpoint:
+    Value: !Sub 'https://${Api}.execute-api.${AWS::Region}.amazonaws.com/${apiStage}'
+  outFn:
+    Value: !Ref Fn

--- a/stateless-mcp-on-lambda-python/src/dependencies/requirements.txt
+++ b/stateless-mcp-on-lambda-python/src/dependencies/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.115.12
+fastmcp==2.3.0
+mcp==1.8.0
+pydantic==2.11.4
+uvicorn==0.34.2

--- a/stateless-mcp-on-lambda-python/src/mcpserver/echo.py
+++ b/stateless-mcp-on-lambda-python/src/mcpserver/echo.py
@@ -1,0 +1,7 @@
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP(name="EchoServer", stateless_http=True)
+
+@mcp.tool(description="A simple echo tool")
+def echo(message: str) -> str:
+    return f"Echo: {message}"

--- a/stateless-mcp-on-lambda-python/src/mcpserver/run.sh
+++ b/stateless-mcp-on-lambda-python/src/mcpserver/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export PATH=$PATH:$LAMBDA_TASK_ROOT/bin
+export PYTHONPATH=$PYTHONPATH:/opt/python:$LAMBDA_RUNTIME_DIR
+exec python -m uvicorn --port=$PORT server:app

--- a/stateless-mcp-on-lambda-python/src/mcpserver/server.py
+++ b/stateless-mcp-on-lambda-python/src/mcpserver/server.py
@@ -1,0 +1,30 @@
+import argparse
+from fastapi import FastAPI
+from echo import mcp
+
+app = FastAPI(title="Echo",lifespan=lambda app: mcp.session_manager.run())
+app.mount("/echo", mcp.streamable_http_app())
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Run the MCP server')
+    parser.add_argument('--mode',
+                       choices=['stdio', 'streamable-http', 'fastapi'],
+                       default='fastapi',
+                       help='Server mode: stdio, streamable-http, or fastapi')
+    parser.add_argument('--host',
+                       default='0.0.0.0',
+                       help='Host for FastAPI server (default: 0.0.0.0)')
+    parser.add_argument('--port',
+                       type=int,
+                       default=8000,
+                       help='Port for FastAPI server (default: 8000)')
+
+    args = parser.parse_args()
+    match args.mode:
+        case 'stdio':
+            mcp.run(transport='stdio')
+        case 'streamable-http':
+            mcp.run(transport='streamable-http')
+        case _:
+            import uvicorn
+            uvicorn.run(app, host=args.host, port=args.port, log_level="info")


### PR DESCRIPTION
*Description of changes:*
Created a python implementation for running stateless MCP servers on Lambda. This is based on the latest MCP python-sdk 1.8.0 release which enabled streamable HTTP servers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
