### PR TITLE
Remove manual lambda layer config

### DIFF
--- a/stateless-mcp-on-lambda-python/README.md
+++ b/stateless-mcp-on-lambda-python/README.md
@@ -47,7 +47,6 @@ Before deploying, you need to configure the environment variables in `etc/enviro
    ```bash
    make layer
    ```
-   After execution, copy the `outLayer` value and update the `O_LAYER_ARN` in `etc/environment.sh`.
 
 2. Deploy the API Gateway and Lambda function:
    ```bash

--- a/stateless-mcp-on-lambda-python/etc/environment.sh
+++ b/stateless-mcp-on-lambda-python/etc/environment.sh
@@ -9,7 +9,7 @@ LAYER_STACK=samples-mcp-lambda-layer
 LAYER_TEMPLATE=sam/layer.yaml
 LAYER_OUTPUT=sam/layer_output.yaml
 LAYER_PARAMS="ParameterKey=description,ParameterValue=${P_DESCRIPTION}"
-O_LAYER_ARN=your-output-layer-arn
+O_LAYER_ARN=will be populated by the script
 
 # api gateway and lambdastack
 P_API_STAGE=dev

--- a/stateless-mcp-on-lambda-python/makefile
+++ b/stateless-mcp-on-lambda-python/makefile
@@ -1,19 +1,28 @@
 include etc/environment.sh
 
 # dependencies
-layer: layer.build layer.package layer.deploy
+layer: layer.build layer.package layer.deploy layer.get-arn
 layer.build:
-	sam build -t ${LAYER_TEMPLATE} --parameter-overrides ${LAYER_PARAMS} --build-dir build --manifest src/dependencies/requirements.txt --use-container
+	sam build -t ${LAYER_TEMPLATE} --parameter-overrides ${LAYER_PARAMS} --build-dir build --manifest src/dependencies/requirements.txt --use-container --region ${REGION} --profile ${PROFILE}
 layer.package:
-	sam package -t build/template.yaml --region ${REGION} --output-template-file ${LAYER_OUTPUT} --s3-bucket ${BUCKET} --s3-prefix ${LAYER_STACK}
+	sam package -t build/template.yaml --region ${REGION} --output-template-file ${LAYER_OUTPUT} --s3-bucket ${BUCKET} --s3-prefix ${LAYER_STACK} --profile ${PROFILE}
 layer.deploy:
-	sam deploy -t ${LAYER_OUTPUT} --region ${REGION} --stack-name ${LAYER_STACK} --parameter-overrides ${LAYER_PARAMS} --capabilities CAPABILITY_NAMED_IAM
+	sam deploy -t ${LAYER_OUTPUT} --region ${REGION} --stack-name ${LAYER_STACK} --parameter-overrides ${LAYER_PARAMS} --profile ${PROFILE}
+layer.get-arn:
+	@echo "Getting layer ARN and updating environment.sh..."
+	$(eval LAYER_ARN := $(shell aws cloudformation describe-stacks --stack-name ${LAYER_STACK} --region ${REGION} --profile ${PROFILE} --query 'Stacks[0].Outputs[?OutputKey==`outLayer`].OutputValue' --output text))
+	@sed -i 's|^O_LAYER_ARN=.*|O_LAYER_ARN=${LAYER_ARN}|' etc/environment.sh
+	@echo "Updated O_LAYER_ARN to: ${LAYER_ARN}"
 
 # api gateway
 apigw: apigw.package apigw.deploy
 apigw.package:
-	sam package -t ${APIGW_TEMPLATE} --output-template-file ${APIGW_OUTPUT} --s3-bucket ${BUCKET} --s3-prefix ${APIGW_STACK}
+	sam package -t ${APIGW_TEMPLATE} --output-template-file ${APIGW_OUTPUT} --s3-bucket ${BUCKET} --s3-prefix ${APIGW_STACK} --region ${REGION} --profile ${PROFILE}
 apigw.deploy:
-	sam deploy -t ${APIGW_OUTPUT} --region ${REGION} --stack-name ${APIGW_STACK} --parameter-overrides ${APIGW_PARAMS} --capabilities CAPABILITY_NAMED_IAM
+	sam deploy -t ${APIGW_OUTPUT} --region ${REGION} --stack-name ${APIGW_STACK} --parameter-overrides ${APIGW_PARAMS} --profile ${PROFILE}
 apigw.delete:
-	sam delete --stack-name ${APIGW_STACK}
+	sam delete --stack-name ${APIGW_STACK} --region ${REGION} --profile ${PROFILE}
+
+delete:
+	sam delete --stack-name ${APIGW_STACK} --region ${REGION} --profile ${PROFILE}
+	sam delete --stack-name ${LAYER_STACK} --region ${REGION} --profile ${PROFILE}


### PR DESCRIPTION
*Issue #, if available:*
Script execution failures when region and profile were not specified in two make commands.

*Description of changes:*
Automated lambda layer configuration to eliminate manual setup steps.

**Problems solved:**
- Fixed script execution failures when region and profile were not specified in two make commands
- Eliminated manual copying of outLayer values
- Removed need to manually provide Layer ARN

**Changes made:**
- Updated Makefile to explicitly specify region and profile parameters
- Enhanced `make layer` command to automatically populate the `environment.sh` file
- Added functionality to automatically set the `0_LAYER_ARN` variable during layer creation

**Benefits:**
- Faster development workflow
- Reduced potential for human error
- More consistent deployments across different environments
- Improved developer experience

**Testing:**
- [x] Verified `make layer` command populates environment.sh correctly
- [x] Confirmed region and profile are properly specified in make commands
- [x] Tested end-to-end deployment workflow

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
